### PR TITLE
Agregar suport per a executar Quartus a macOS ARM

### DIFF
--- a/Multiprocessadors.md
+++ b/Multiprocessadors.md
@@ -51,6 +51,11 @@ Executar Quartus:
 $QUARTUS_PATH/shell/quartus
 ```
 
+Executar Quartus a macOS:
+```bash
+$QUARTUS_PATH/shell-macos/quartus
+```
+
 ## ModelSim
 Si al executar modelsim teniu un error de llicencies, heu de seleccionar una altra versió de ModelSim.
 
@@ -58,3 +63,70 @@ Aneu a `Tools->Options->EDA Tool Options` i a la ruta de ModelSim poseu la versi
 ```
 /opt/altera/13.0sp1/modelsim_ase/linuxaloem
 ```
+
+# Instalar entorn per a macOS ARM M1+
+
+És possible executar Quartus i Modelsim a un màquina Mac amb el processador M1 o superior.
+Per fer-ho, primerament és necessari tenir instalat el gestor de paquets Homebrew. Per fer-ho,
+consulteu https://brew.sh .
+
+Un cop instalat Homebrew, cal instalar els següents paquets.
+
+## Docker
+```
+brew install docker
+brew install docker-compose
+```
+
+## Colima
+```
+brew install colima
+brew install lima-additional-guestagents
+```
+
+## QEMU
+```
+brew install qemu
+```
+
+## XQuartz
+```
+brew install --cask xquartz
+```
+
+## IMPORTANT
+Seguint les mateixes instruccions que es descriuen més amunt per instalar Quartus i Modelsim, abans d'executar Docker és necessari inicialitzar Colima perquè s'iniciï l'entorn de la màquina virtual. També cal configurar les variables d'entorn necessàries perquè XQuartz pugui funcionar correctament. A continuació s'explica com fer-ho.
+
+### Inicialitzar Colima
+```bash
+colima start --arch x86_64 --vz-rosetta
+```
+
+Si es vol assignar més recursos (memòria i cores) a la màquina virtual, executa:
+```bash
+colima start --arch x86_64 --vz-rosetta --memory X --cpu Y
+```
+*Precaució:* Els paràmetres de memòria dependran dels recursos disponibles a la vostra màquina.
+Si s'assignen massa recursos, és possible patir problemes a la màquina host i congelar el sistema. L'ideal és assignar un 40-60% de la RAM total i de 2 a 4 cores.
+
+### Inicialitzar correctament la variable d'entorn DISPLAY
+
+```bash
+export DISPLAY=:0
+```
+
+### Donar permís a connexions locals per emprar XQuartz
+
+Executar:
+```bash
+open -a XQuartz
+```
+
+Anar a XQuartz -> Settings -> Security -> Allow connections from network clients.
+
+Executar:
+```bash
+xhost +local:
+```
+
+Continuar les instruccions que s'expliquen més amunt per a instalar Quartus i Modelsim.

--- a/Multiprocessadors.md
+++ b/Multiprocessadors.md
@@ -64,13 +64,13 @@ Aneu a `Tools->Options->EDA Tool Options` i a la ruta de ModelSim poseu la versi
 /opt/altera/13.0sp1/modelsim_ase/linuxaloem
 ```
 
-# Instalar entorn per a macOS ARM M1+
+# Instal·lar entorn per a macOS ARM M1+
 
 És possible executar Quartus i Modelsim a un màquina Mac amb el processador M1 o superior.
 Per fer-ho, primerament és necessari tenir instalat el gestor de paquets Homebrew. Per fer-ho,
 consulteu https://brew.sh .
 
-Un cop instalat Homebrew, cal instalar els següents paquets.
+Un cop instal·lat Homebrew, cal instalar els següents paquets.
 
 ## Docker
 ```
@@ -95,7 +95,7 @@ brew install --cask xquartz
 ```
 
 ## IMPORTANT
-Seguint les mateixes instruccions que es descriuen més amunt per instalar Quartus i Modelsim, abans d'executar Docker és necessari inicialitzar Colima perquè s'iniciï l'entorn de la màquina virtual. També cal configurar les variables d'entorn necessàries perquè XQuartz pugui funcionar correctament. A continuació s'explica com fer-ho.
+Seguint les mateixes instruccions que es descriuen més amunt per instal·lar Quartus i Modelsim, abans d'executar Docker és necessari inicialitzar Colima perquè s'iniciï l'entorn de la màquina virtual. També cal configurar les variables d'entorn necessàries perquè XQuartz pugui funcionar correctament. A continuació s'explica com fer-ho.
 
 ### Inicialitzar Colima
 ```bash

--- a/Multiprocessadors.md
+++ b/Multiprocessadors.md
@@ -109,6 +109,8 @@ colima start --arch x86_64 --vz-rosetta --memory X --cpu Y
 *Precaució:* Els paràmetres de memòria dependran dels recursos disponibles a la vostra màquina.
 Si s'assignen massa recursos, és possible patir problemes a la màquina host i congelar el sistema. L'ideal és assignar un 40-60% de la RAM total i de 2 a 4 cores.
 
+Aquesta comanda s'haura d'executar abans d'instalar Quartus i cada cop que es vulgui executar-lo.
+
 ### Inicialitzar correctament la variable d'entorn DISPLAY
 
 ```bash
@@ -130,3 +132,9 @@ xhost +local:
 ```
 
 Continuar les instruccions que s'expliquen més amunt per a instalar Quartus i Modelsim.
+
+### Parar l'execució de Colima
+
+```bash
+colima stop
+```

--- a/shell-macos/quartus
+++ b/shell-macos/quartus
@@ -1,0 +1,2 @@
+#!/bin/bash
+source $( dirname "$0" )/quartus13.sh quartus $@

--- a/shell-macos/quartus13.sh
+++ b/shell-macos/quartus13.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+QUARTUS13_IMAGE=${QUARTUS13_IMAGE:-"quartus:13.0.1.2"}
+LICENSE_MAC=${LICENSE_MAC:-"00:FF:FF:FF:FF:FF"}
+LM_LICENSE_FILE=${LM_LICENSE_FILE:-"$HOME/.Altera/quartus.dat"}
+MGLS_LICENSE_FILE=${MGLS_LICENSE_FILE:-"$HOME/.Altera/modelsim.dat"}
+
+QUARTUS_PATH=/opt/altera/13.0sp1/quartus/linux64
+
+docker run --rm \
+--user $(id -u):$(id -g) \
+-e DISPLAY=host.docker.internal:0 \
+-e PATH=/bin:/sbin:$QUARTUS_PATH \
+-e LD_LIBRARY_PATH=$QUARTUS_PATH \
+-e LM_LICENSE_FILE=$LM_LICENSE_FILE \
+-e MGLS_LICENSE_FILE=$MGLS_LICENSE_FILE \
+--mac-address=$LICENSE_MAC \
+-v /etc/passwd:/etc/passwd:ro \
+-v /etc/group:/etc/group:ro  \
+-v $HOME/.Xauthority:/root/.Xauthority \
+-v $HOME:$HOME \
+-w $PWD \
+--ipc=host \
+-v /dev/bus/usb:/dev/bus/usb \
+--device-cgroup-rule='c *:* rmw' \
+--security-opt seccomp=unconfined \
+-ti $QUARTUS13_IMAGE $@

--- a/shell-macos/quartus_asm
+++ b/shell-macos/quartus_asm
@@ -1,0 +1,2 @@
+#!/bin/bash
+source $( dirname "$0" )/quartus13.sh quartus_asm $@

--- a/shell-macos/quartus_fit
+++ b/shell-macos/quartus_fit
@@ -1,0 +1,2 @@
+#!/bin/bash
+source $( dirname "$0" )/quartus13.sh quartus_fit $@

--- a/shell-macos/quartus_map
+++ b/shell-macos/quartus_map
@@ -1,0 +1,2 @@
+#!/bin/bash
+source $( dirname "$0" )/quartus13.sh quartus_map $@

--- a/shell-macos/quartus_pgm
+++ b/shell-macos/quartus_pgm
@@ -1,0 +1,2 @@
+#!/bin/bash
+source $( dirname "$0" )/quartus13.sh quartus_pgm $@

--- a/shell-macos/quartus_sta
+++ b/shell-macos/quartus_sta
@@ -1,0 +1,2 @@
+#!/bin/bash
+source $( dirname "$0" )/quartus13.sh quartus_sta $@


### PR DESCRIPTION
He agregat les modificacions necessàries per poder instalar i executar Quartus i Modelsim a macOS ARM M1 o superior.

He afegit indicacions al README per si algun company té una Mac, pugui instal·lar-s'ho i fer funcionar els programes.
He modificat l'script quartus13.sh per que sigui compatible amb XQuartz a macOS. Per no modificar l'original, ho he posat al directori *shell-macos*.